### PR TITLE
[Note] Support encrypted notesnook monograph

### DIFF
--- a/money/notes/notesnook.py
+++ b/money/notes/notesnook.py
@@ -1,15 +1,95 @@
-from .parser import NotesParser
-import requests
 from bs4 import BeautifulSoup
+from Crypto.Cipher import ChaCha20_Poly1305
+from base64 import urlsafe_b64decode
+import argon2
+import json
+import re
+import requests
+from .parser import NotesParser
+
+
+AEAD_XCHACHA20POLY1305_IETF_KEYLEN = 32
+ENCRYPTED_CONTENT_REGEX = r'(?<="encryptedContent":){[\s\S]*?}(?=,"datePublished")'
+
+
+class Decryptor:
+    def b64_decode(base64_string):
+        # Add padding if necessary (Base64 URL-safe can omit padding)
+        padding = "=" * (4 - len(base64_string) % 4)
+        base64_string += padding
+        return urlsafe_b64decode(base64_string)
+
+    def get_password_from_url(url: str):
+        splits = url.split("#key=") + [""]
+        key = splits[1]
+        return Decryptor.b64_decode(key) if key else None
+
+    # https://github.com/streetwriters/notesnook/blob/master/apps/monograph/app/components/monographpost/index.tsx#L689
+    def decrypt(
+        password: bytes,
+        cipher: str,
+        iv: str = None,
+        salt: str = None,
+        length: str = None,
+    ):
+        # Decode the base64 strings to get the actual binary data
+        if isinstance(password, str):
+            password = password.encode()
+        iv = Decryptor.b64_decode(iv)
+        ciphertext = Decryptor.b64_decode(cipher)
+        salt = Decryptor.b64_decode(salt)
+
+        key = argon2.low_level.hash_secret_raw(
+            secret=password,
+            salt=salt,
+            time_cost=3,
+            memory_cost=8 * 1024,
+            parallelism=1,
+            hash_len=AEAD_XCHACHA20POLY1305_IETF_KEYLEN,
+            type=argon2.Type.I,
+        )
+
+        # XChaCha20_Poly1305 is 24-bytes Nonce version
+        cipher = ChaCha20_Poly1305.new(key=key, nonce=iv)
+
+        decrypted = cipher.decrypt(ciphertext)
+        decrypted_obj = (
+            json.loads(decrypted[:length] if length else decrypted) if decrypted else {}
+        )
+
+        # Output the plaintext as a string
+        return decrypted_obj.get("data", "")
 
 
 class NotesnookParser(NotesParser):
+    def get_encrypted_data(response_text: str) -> dict:
+        match = re.search(ENCRYPTED_CONTENT_REGEX, response_text)
+        if not match:
+            return {}
+        return json.loads(match.group())
+
     def parse(monograph_url: str) -> list:
         response = requests.get(monograph_url)
         if not response.status_code == 200:
-            return []
+            raise RuntimeError("Fail to get Notesnook note")
 
-        soup = BeautifulSoup(response.text, "html.parser")
+        encrypted_data = NotesnookParser.get_encrypted_data(response.text)
+        password = Decryptor.get_password_from_url(monograph_url)
+        if encrypted_data and not password:
+            raise RuntimeError("Require password to parse Notesnook note")
+        if not encrypted_data:
+            text = response.text
+        else:
+            try:
+                text = Decryptor.decrypt(password=password, **encrypted_data)
+            except:
+                raise RuntimeError(
+                    "Fail to decrypt Notesnook note, maybe because of wrong password"
+                )
+        if not text:
+            raise RuntimeError("Fail to parse Notesnook note")
+
+        soup = BeautifulSoup(text, "html.parser")
 
         tables = soup.find_all("table")
 

--- a/money/prototype/note.py
+++ b/money/prototype/note.py
@@ -23,7 +23,7 @@ class NotePrototype(Prototype):
             ]
         ),
         arguments={
-            "resource": "r (str[telex]): reference a saved resource by id or name",
+            "resource": "r (str): reference a saved resource by id or name",
             "force": "f (bool = 0): force to import all notes from resource and by pass all duplicating checks",
             "reserved": "s, save (str = .): folder to store notes that are not imported successfully (due to errors)",
         }
@@ -67,11 +67,14 @@ class NotePrototype(Prototype):
         )
 
         # get new notes
-        new_data = NoteHelper.parse_from_url(
-            resource_link,
-            None if args.force else last_import_record,
-            (options or {}).get("format"),
-        )
+        try:
+            new_data = NoteHelper.parse_from_url(
+                resource_link,
+                None if args.force else last_import_record,
+                (options or {}).get("format"),
+            )
+        except Exception as err:
+            return response.message("exception", message=err, argument=resource_link)
         count = len(new_data)
         if not count:
             return response.message(

--- a/money/prototype/note.py
+++ b/money/prototype/note.py
@@ -63,15 +63,16 @@ class NotePrototype(Prototype):
             link=args.link,
             scope=args.scope,
             last_record=None,
-            option=dict(args.option or {}),
+            option=None,
         )
+        options = (options or {}) | dict(args.option or {})
 
         # get new notes
         try:
             new_data = NoteHelper.parse_from_url(
                 resource_link,
                 None if args.force else last_import_record,
-                (options or {}).get("format"),
+                options.get("format"),
             )
         except Exception as err:
             return response.message("exception", message=err, argument=resource_link)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ python = "^3.10"
 cmdapp = {path = "../cmdapp", develop = true}
 beautifulsoup4 = "^4.12.3"
 requests = "^2.32.3"
+pycryptodome = "^3.21.0"
+argon2-cffi = "^23.1.0"
 
 
 [build-system]


### PR DESCRIPTION
**Feature**:
- Notesnook monograph has end-to-end encryption feature, so this PR provide codes to **decrypt one with provided password** (that was base64-encoded in the URL: `https://monogr.ph/<monograph_id>#key=<base64_encoded_password>`)
- The algorithm is:
  - **Argon2I13** (Argon2, Type I, version 13) for key derivation
  - **XChaCha20 Poly1305** for encrypting
- **Reference**: https://github.com/streetwriters/notesnook/blob/master/apps/monograph/app/components/monographpost/index.tsx#L689